### PR TITLE
Incorporation of InnerSource Tooling Documentation

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -30,3 +30,8 @@
     * [Allow Innovation in Detail](measuring/metrics.md#allow-innovation-in-detail)
   * [References](measuring/references.md)
   * [Authors and Reviewers](measuring/authors.md)
+* [Tooling](tooling/innersource-tooling.md)
+  * [GitHub Strategy](tooling/github-strategy.md)
+  * [GitHub Configuration](tooling/github-configuration.md)
+  * [GitLab Strategy](tooling/gitlab-strategy.md)
+  * [GitLab Configuration](tooling/gitlab-configuration.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -35,3 +35,4 @@
   * [GitHub Configuration](tooling/github-configuration.md)
   * [GitLab Strategy](tooling/gitlab-strategy.md)
   * [GitLab Configuration](tooling/gitlab-configuration.md)
+  * [Authors and Reviewers](tooling/authors.md)

--- a/tooling/authors.md
+++ b/tooling/authors.md
@@ -8,3 +8,5 @@
 ## Reviewers
 
 (Chronological order)
+
+- Guilherme Dellagustin ([SAP](https://sap.com/))

--- a/tooling/authors.md
+++ b/tooling/authors.md
@@ -1,0 +1,10 @@
+## Authors
+
+(Chronological order)
+
+- Justin Gosses ([Microsoft](https://microsoft.com/))
+- Yuki Hattori ([GitHub](https://github.com/))
+
+## Reviewers
+
+(Chronological order)

--- a/tooling/github-configuration.md
+++ b/tooling/github-configuration.md
@@ -1,0 +1,89 @@
+# GitHub InnerSource Configuration
+
+## Enterprise Setting
+
+### Repository policies
+
+#### Base permissions
+
+When setting up the base repository permissions to promote InnerSource within your organization on GitHub, it's important to strike a balance between transparency, collaboration, and respecting constraints and limitations. Here are some best practices for setting up repository permissions:
+
+| Permission | Description |
+| --- | --- |
+| No Policy | Inherit permissions from the organization or parent repository. Provides flexibility for projects with unique permission needs. |
+| No Permission | Not recommended if any of the repositories in that org might benefit from collaboration. Completely restricts access to the repository, hindering collaboration and knowledge sharing. Repository access requires finding and talking to org owners. |
+| Read | All organization members can view the repository's contents, promoting transparency and allowing employees to learn from each other's work. |
+| Write | Specific individuals or teams with the "Write" permission can make contributions to the repository. Grant to active InnerSource participants with relevant skills. |
+| Admin | Limited to a select group responsible for managing the repository and overseeing InnerSource initiatives. Handles repository configuration and review processes. |
+
+It is better to choose No Policy and let the user choose, but it is also a good idea to consciously choose Read permission.
+
+#### Repository creation
+
+Allowing most users to create only Private or Internal type repositories is a measure often taken.
+It's important to consider your organization's policies and the nature of the projects when deciding on repository creation settings. Striking a balance between encouraging collaboration and managing access to sensitive information is crucial in an InnerSource context. Providing options for members to create repositories, while defining guidelines and permissions, can support innovation and knowledge sharing within the organization.
+
+| Repository Creation | Description | Recommendation |
+| --- | --- | --- |
+| No Policy | Organization owners can choose whether to allow members to create repositories. | Provide flexibility for members to create repositories based on project needs, encouraging collaboration. |
+| Disabled | Members will not be able to create repositories. | Discourages repository creation and may hinder InnerSource practices. Consider enabling creation for collaboration. |
+| Members can create repositories | Members are allowed to create repositories, but with restrictions on the types available (public, private, internal). | Encourage the creation of repositories while specifying the types that align with your organization's guidelines. |
+| ┣ Public | Members can create public repositories visible to everyone on GitHub. | Promote open sharing and collaboration with both internal and external stakeholders. |
+| ┣  Private | Members can create private repositories accessible only to invited collaborators. | Encourage team-specific or sensitive projects that require restricted access. |
+| ┗ Internal | Members can create internal repositories visible to organization members. | Foster collaboration and knowledge sharing within the organization while keeping information proprietary. |
+
+#### Repository forking (Private / Internal)
+
+The decision to allow or restrict repository forking depends on your organization's policies and the level of control and security required for your codebase. Enabling forking generally promotes collaboration, allows for experimentation, and encourages the InnerSource principles of sharing and contribution. However, it's important to assess the risks and consider any regulatory or compliance requirements before allowing forking in private and internal repositories.
+
+| Repository Forking | Description | Recommendation |
+| --- | --- | --- |
+| No Policy | Organizations choose whether to allow private and internal repositories to be forked. | Provide flexibility for forking private and internal repositories based on project needs. This allows teams to collaborate and contribute to codebases while maintaining control over access and security. |
+| Enabled | Organizations always allow private and internal repositories to be forked. | Encourage forking of private and internal repositories to promote collaboration and foster a culture of contribution. Forking enables individuals or teams to make modifications and propose changes without directly impacting the original codebase. |
+| Disabled | Organizations never allow private or internal repositories to be forked. | In an InnerSource context, it is recommended to enable forking to encourage collaboration, knowledge sharing, and innovation. Forking allows individuals or teams to experiment, improve, and contribute without directly modifying the original codebase. |
+
+## Organization Setting
+
+### Member privileges
+
+#### Base permissions
+
+At the Organization Level, you can further refine repository permissions within specific organizations. This allows you to tailor access control to each organization's unique requirements. Some recommended practices for repository permission settings at the Organization Level include:
+
+- Granting appropriate permissions to organization members based on their roles and responsibilities.
+- Providing read access to all organization members, promoting transparency and knowledge sharing.
+- Granting write access to individuals or teams actively participating in InnerSource projects, who have demonstrated the necessary skills and knowledge.
+- Designating a select group with admin permissions responsible for managing repositories, overseeing InnerSource initiatives, and maintaining repository settings.
+
+#### Repository creation
+
+When configuring repository creation settings at the Organization Level, it's essential to align them with your organization's goals, policies, and security requirements. Allowing members to create repositories with specific types (public, private, internal) provides flexibility and promotes InnerSource practices.
+
+#### Repository forking
+
+When making a decision about forking from private and internal repositories for InnerSource projects, carefully evaluate these factors to find the most appropriate approach for your organization's specific context.
+
+| Factors to Consider | Description |
+| --- | --- |
+| Collaboration and Contribution | Allowing forking promotes collaboration and contribution within the organization. It enables individuals or teams to make modifications and propose changes without directly impacting the original codebase, fostering a decentralized approach to innovation. |
+| Access Control | Evaluate the sensitivity of the code and the level of control required for the project. If the InnerSource project involves sensitive information or requires stricter access control, it may not be suitable to allow forking from private or internal repositories. Consider limiting forking to specific repositories or restricting it altogether. |
+| Security and Intellectual Property | Assess the potential risks associated with forking, such as the exposure of proprietary code or intellectual property. If forking could lead to unintended disclosure of sensitive information, it may be necessary to disable forking from private and internal repositories. |
+| Project Scope and Collaboration Scope | Determine the scope of the InnerSource project and the desired collaboration boundaries. If the project involves cross-functional teams or collaboration with external contributors, allowing forking from private and internal repositories may promote broader engagement and involvement. |
+| Internal Policies and Compliance | Consider any internal policies, regulations, or compliance requirements that may impact the decision to allow forking from private and internal repositories. Ensure that the practice aligns with your organization's guidelines and legal obligations. |
+
+## GitHub Enterprise Server Setting
+
+### GitHub Connect - Server statistics
+
+Enabling Server Statistics in your GitHub Enterprise Server environment can provide valuable insights into the activities and usage patterns within your GitHub Enterprise Server. Here are the recommended settings and the reasons why enabling Server Statistics is beneficial:
+
+| Reason | Description |
+| --- | --- |
+| Usage Analysis | Server Statistics provide data on the number of pushes, pull requests, issue creations, and other relevant activities. Analyzing this data can help you understand the usage patterns and trends within your server. |
+| Identify Collaborative Opportunities | Analyzing Server Statistics can help identify areas where collaboration can be improved. For example, a low pull request count and issue count in the server may indicate opportunities to foster collaboration and encourage more code reviews and contributions. |
+| Measure Impact | Server Statistics allow you to track the impact of initiatives, such as introducing InnerSource practices or promoting open-source contributions. Monitoring pull requests or external contributions helps gauge the success and effectiveness of these initiatives and make data-driven decisions. |
+| Continuous Improvement | Enabling Server Statistics enables measuring the effectiveness of process improvements or development practices. Tracking metrics like time to resolve issues, code review turnaround time, or code quality improvements helps identify bottlenecks and areas for improvement. |
+
+## Resources
+
+- [Orgs and Teams Best Practices · GitHub](https://gist.github.com/rwnfoo/3e19747f6dc2c5b9cfb0ff9c89d834b4)

--- a/tooling/github-configuration.md
+++ b/tooling/github-configuration.md
@@ -1,5 +1,19 @@
 # GitHub InnerSource Configuration
 
+- [Enterprise Setting](#enterprise-setting)
+  - [Repository policies](#repository-policies)
+    - [Base permissions](#base-permissions)
+    - [Repository creation](#repository-creation)
+    - [Repository forking (Private / Internal)](#repository-forking-private--internal)
+- [Organization Setting](#organization-setting)
+  - [Member privileges](#member-privileges)
+    - [Base permissions](#base-permissions-1)
+    - [Repository creation](#repository-creation-1)
+    - [Repository forking](#repository-forking)
+- [GitHub Enterprise Server Setting](#github-enterprise-server-setting)
+  - [GitHub Connect - Server statistics](#github-connect---server-statistics)
+- [Resources](#resources)
+
 ## Enterprise Setting
 
 ### Repository policies

--- a/tooling/github-configuration.md
+++ b/tooling/github-configuration.md
@@ -22,7 +22,7 @@
 
 When setting up the base repository permissions to promote InnerSource within your organization on GitHub, it's important to strike a balance between transparency, collaboration, and respecting constraints and limitations. Here are some best practices for setting up repository permissions:
 
-| Permission | Description |
+| Repository Permission | Description |
 | --- | --- |
 | No Policy | Inherit permissions from the organization or parent repository. Provides flexibility for projects with unique permission needs. |
 | No Permission | Not recommended if any of the repositories in that org might benefit from collaboration. Completely restricts access to the repository, hindering collaboration and knowledge sharing. Repository access requires finding and talking to org owners. |

--- a/tooling/github-strategy.md
+++ b/tooling/github-strategy.md
@@ -1,5 +1,13 @@
 # GitHub InnerSource Strategies
 
+- [Balancing Security \& InnerSource: Who Can See What](#balancing-security--innersource-who-can-see-what)
+- [Security-First Perspective and InnerSource-first Perspective](#security-first-perspective-and-innersource-first-perspective)
+- [Visibility Differences by InnerSource Project Type](#visibility-differences-by-innersource-project-type)
+- [Project Participation Difficulty Level by Setting](#project-participation-difficulty-level-by-setting)
+- [Pros and Cons of InnerSource Dedicated Environment](#pros-and-cons-of-innersource-dedicated-environment)
+- [Variations in how repository read access is distributed](#variations-in-how-repository-read-access-is-distributed)
+- [Conclusion: High Level Guideline](#conclusion-high-level-guideline)
+
 ## Balancing Security & InnerSource: Who Can See What
 
 The section explores the delicate balance between security and collaboration in the context of InnerSource projects. Within an InnerSource project, transparency plays a vital role in fostering collaboration and encouraging participation. Ideally, the project should be structured to allow as many individuals as possible to contribute, ensuring that the barriers to participation are kept low. However, it's important to acknowledge that certain constraints and considerations may prevent making everything openly accessible within the company.

--- a/tooling/github-strategy.md
+++ b/tooling/github-strategy.md
@@ -1,0 +1,84 @@
+# GitHub InnerSource Strategies
+
+## Balancing Security & InnerSource: Who Can See What
+
+The section explores the delicate balance between security and collaboration in the context of InnerSource projects. Within an InnerSource project, transparency plays a vital role in fostering collaboration and encouraging participation. Ideally, the project should be structured to allow as many individuals as possible to contribute, ensuring that the barriers to participation are kept low. However, it's important to acknowledge that certain constraints and considerations may prevent making everything openly accessible within the company.
+
+To strike a balance between encouraging InnerSource participation and respecting the company's constraints, it becomes necessary to carefully consider different levels of code sharing and establish appropriate Source Code Management (SCM) practices. This allows for the implementation of controlled visibility and access mechanisms, ensuring that sensitive or proprietary code remains protected while still enabling collaboration and knowledge sharing.
+
+By defining these various levels of sharing, organizations can customize their SCM setup to accommodate their specific needs. This may involve setting up different repositories or access controls based on the sensitivity of the code, project type, or individual roles within the organization. Through thoughtful planning and implementation, companies can create an InnerSource environment that maximizes participation while upholding necessary restrictions.
+
+By effectively managing transparency and sharing levels, organizations can foster a culture of InnerSource collaboration that strikes the right balance between openness and the company's specific constraints. This approach enables individuals to contribute their expertise, fosters innovation, and strengthens the overall development process within the organization.
+
+## Security-First Perspective and InnerSource-first Perspective
+
+There are two perspectives presented in the table: the Security-First Perspective and the InnerSource-First Perspective. By considering these two perspectives, companies can address the risks associated with sensitive code leaving the organization while also fostering collaboration and sharing of code within the company for increased productivity and innovation.
+
+| ​ | Security-First Perspective​ | InnerSource-first perspective​ |
+| --- | --- | --- |
+| Concerned with What Risk?​ | Sensitive code gets outside Company. ​ | No effective way for anyone at company to search, discover, or evaluate code for use created outside their org.​ |
+| Absolute positions for each perspective​ | All repositories should be their own silo. Access to know each repo exists only individually granted by upper management.​ | All repositories should be visible to all FTEs.​ |
+| What Repositories are the Perspective’s Focus?​ | Sensitive repositories: Those whose release has market impact or is core infrastructure with safety implications.​ | Highly reusable packages, internal reusable tools, templates, examples, or code that builds services many people have stake in like websites, SDKs, etc. ​ |
+
+The opportunity to balance both needs comes from observation that there is not much overlap between the repositories that each perspective cares about the most.
+
+## Visibility Differences by InnerSource Project Type
+
+There are several types of InnerSource projects, each with its own characteristics and considerations. The table provides an overview of these project types and their visibility differences within an organization. What kinds of InnerSource seeds does your organization have? What areas in your organization would you like to start with when strategically adopting InnerSource? Use this categorization to help you categorize your project.
+
+| Type of InnerSource​ | InnerSource Participation method​ | Significant Communication before pull request or reuse?​ | Will owning party likely know non-owning party beforehand​ | numbers of chances for InnerSource participation killed off by org-level visibility boundaries​ | Enterprise impact of InnerSource action not occurring​ | Likely sensitivity of the code if maliciously released​ |
+| --- | --- | --- | --- | --- | --- | --- |
+| Learning, copy and pasting (examples, templates)​ | Learning​ | None​ | No​ | Most​ | Entropy and lost time.​ | Probably low​ |
+| Use Reusable tools built for Company circumstances. ​ | Reuse​ | None-little​ | No​ | Many​ | Loss of efficiency and speed. ​ | Probably low​ |
+| Content change, fix, add, or update (websites, documentation)​ | Contribution, small ones​ | None-little​ | No​ | Many​ | Wasted time due to bad information.​ | Probably low​ |
+| Build within someone else's internal service | Contribution, within well-defined parameters​ | Yes​ | No​ | Some​ | More things never done at all.​ | Probably low but more exceptions.​ |
+| Deduplication. Don't built same thing twice, build general solution.​ | Contribution ​ | Yes​ | Varies​ | Some​ | General purpose code written less often. ​ | Depends, some very high.​ |
+| Ensure alignment between related projects​ | Contribution ​ | Yes​ | Likely​ | A few​ | Loss of efficiency and speed.​ | Depends, some very high.​ |
+| Not get slowed down by who is owning ​ | Contribution ​ | Yes​ | Likely​ | A few​ | Loss of efficiency and speed.​ | Depends, some very high.​ |
+
+## Project Participation Difficulty Level by Setting
+
+The difficulty level to join a project depends on your access rights to GitHub Enterprise and the repository type. It should be noted that GitHub settings in the enterprise often use SCIM and work with IdPs such as Microsoft Entra and Okta, but the participation hurdle can also vary depending on the settings on the IdP side.
+
+Here are groups that can be used to define repository permissions ordered by process toil to join:
+
+1. Everyone behind company firewall
+1. Internal visibility​ (everyone on platform is in this group)
+1. Security group created automatically​
+1. Security group with self-join and NO forced renew after X time period​
+1. Security group with self-join and forced renew after X time period​
+1. Security group with self-initiated but requires waiting for manager permission.
+1. Security group with that requires emailing someone to manually add you
+
+## Pros and Cons of InnerSource Dedicated Environment
+
+Although InnerSource catalogs and organizations specifically for InnerSource have benefits, they should not be viewed as a place that holds “ALL” InnerSource.
+
+| Approach​ | Definition​ | Advantages​ | Disadvantages​ |
+| --- | --- | --- | --- |
+| InnerSource Catalogs | Repositories that want extra visibility self-select via topic tag. They are then harvested into a separate catalog.​ | Have some of the repos most interested in being reused in one place helps measurement & discovery of them.​ | Most users won’t troll a catalog separate from their workflow.​ There is a risk a perception is created that only repos in that catalog are innerSource.​ |
+| Dedicated Organization for InnerSource​ | Repos for a need to be shared widely are put in an org specifically for that purposeR​ | Heightens visibility for the repos in that org.​ | Most InnerSource occurs in Repositories that do not see InnerSource as focus or reason for existence.​ Requires moving code outside team’s main org, breaks links and workflows.​ |
+| Platform-wide Internal Visibility​ | GitHub provides an “internalVisibility” repo setting that enables a repo to be visible to all platform members.​ | Enables sharing at scale large enough for effective search & discovery.​ Applies to individual repos instead of orgs. ​| Requires trusting staff to only apply internalVisibility to lower risk repos with higher sharing needs. ​A repo centric approach may feel less traditional to orgs that have previously kept code within team or organization walled environments. |
+
+## Variations in how repository read access is distributed
+
+The extent to which a repository is visible to enterprise users varies between everyone in the enterprise, everyone in a GitHub organization, everyone within a GitHub team, or users given permissions to a repository individually. A GitHub team can either be a small or large group of individuals independent of organizational membership. Team memberships can be handled with GitHub’s interface or via a separate enterprise identity and permissions tracking system that has API connection to GitHub.
+
+| Approach​ | Definition​ | Advantages​ | Disadvantages​ |
+| --- | --- | --- | --- |
+| Internal Visible repository | A repository that is internally visible is visible to everyone in the GitHub enterprise. | Easy discovery and quick contributions through forks across the entire enterprise. | Visible to anyone who is a member of the enterprise, which is sometimes not wanted. |
+| Repositories visible to any organization member | Members of an organization get read access to all repositories in an organization by default. | Low process burden for discovery and collaboration within that organization.​ | When org membership gives read rights to all repositories in the org and org membership is the only way to gain read permissions to a given repository, users must effectively request access to all repositories in an org even if they only need access to a single less sensitive repository. This makes it hard to control access to more sensitive repositories that may exist in the org. |
+| Repository visibility given to GitHub Teams | A team can be a small subset of users within an organization, or a group of users from across a subset of many organizations within the enterprise. Teams can be associated with more than one repository | Flexibility. Read permissions can be distributed to one or many repositories at a time and to users outside org membership boundaries. | Purposes of GitHub teams need to be documented and followed to avoid unintended creep in team membership and usage over time. |
+| Repository visibility given to individuals | Read permissions can be given to individual members in the repository settings | Ability to given repository access one person at a time, similar to team-based repository | Permissions given individually involve more process burdens to give and remove. There is no possibility for users to discover a useful repository on their own. Requires admin access to the repository settings to set. |
+
+These levels of read permissions can be combined within a given GitHub organization. A single organization can have all four from the table above. Enterprise and organization level rules can determine what levels of READ permission are possible for repository owners to pick from.
+
+It is worth pointing out that the only way to enable a GitHub organization to have both repositories shared across the enterprise and repositories that are tightly controlled such that only a small subset of organization members can see them is to (1) enable read permissions to be decided at the repository level and (2) not automatically give read permissions to every repository in the organization to every member of the organization.
+
+Although in the general case it may be ideal to give repositories a range of read permissions styles to pick from, there can be reasons for specific organizations to not give repositories that flexibility. A specific organization may be set up only for code that must always be limited to a small subset of users. Alternatively, an organization may be set up only for code that is meant to be widely shared within the enterprise.
+
+## Conclusion: High Level Guideline
+
+- It is advisable to anticipate the need for various levels of sharing, ranging from company-wide to small groups, for repositories within large platform organizations.
+- Granting repository owners the authority to manage visibility and permissions is more effective than having organization or enterprise owners set them. This approach prevents narrow policies set at higher levels from becoming burdensome over time as needs evolve.
+- Collaborative efforts often begin with uncertain value propositions. Consequently, even minor procedural obstacles can prematurely terminate these initiatives. To mitigate this, establish processes that enable repository discovery and evaluation without requiring permission requests whenever feasible.

--- a/tooling/gitlab-configuration.md
+++ b/tooling/gitlab-configuration.md
@@ -1,0 +1,1 @@
+# GitLab InnerSource Configuration

--- a/tooling/gitlab-strategy.md
+++ b/tooling/gitlab-strategy.md
@@ -1,0 +1,1 @@
+# GitLab InnerSource Strategies

--- a/tooling/innersource-tooling.md
+++ b/tooling/innersource-tooling.md
@@ -1,0 +1,34 @@
+# InnerSource with GitHub
+
+## Effective InnerSource Strategies and Configuration for GitHub
+
+This documentation is a compilation of the essential settings and strategies necessary for implementing InnerSource inside an organization. It encompasses both overall strategic elements and specific points relating to SCM configuration.
+
+## Table of Contents
+
+### GitHub
+
+- [GitHub InnerSource Strategies](tooling/github-strategy.md#github-innersource-strategies)
+  - [Balancing Security \& InnerSource: Who Can See What](tooling/github-strategy.md#balancing-security--innersource-who-can-see-what)
+  - [Security-First Perspective and InnerSource-first Perspective](tooling/github-strategy.md#security-first-perspective-and-innersource-first-perspective)
+  - [Visibility Differences by InnerSource Project Type](tooling/github-strategy.md#visibility-differences-by-innersource-project-type)
+  - [Project Participation Difficulty Level by Setting](tooling/github-strategy.md#project-participation-difficulty-level-by-setting)
+  - [Pros and Cons of InnerSource Dedicated Environment](tooling/github-strategy.md#pros-and-cons-of-innersource-dedicated-environment)
+  - [Variations in how repository read access is distributed](tooling/github-strategy.md#variations-in-how-repository-read-access-is-distributed)
+  - [Conclusion: High Level Guideline](tooling/github-strategy.md#conclusion-high-level-guideline)
+- [GitHub InnerSource Configuration](tooling/github-configuration.md/#github-innersource-configuration)
+  - [Enterprise Setting](tooling/github-configuration.md/#enterprise-setting)
+    - [Repository policies](tooling/github-configuration.md/#repository-policies)
+      - [Base permissions](tooling/github-configuration.md/#base-permissions)
+      - [Repository creation](tooling/github-configuration.md/#repository-creation)
+      - [Repository forking (Private / Internal)](tooling/github-configuration.md/#repository-forking-private--internal)
+  - [Organization Setting](tooling/github-configuration.md/#organization-setting)
+    - [Member privileges](tooling/github-configuration.md/#member-privileges)
+      - [Base permissions](tooling/github-configuration.md/#base-permissions-1)
+      - [Repository creation](tooling/github-configuration.md/#repository-creation-1)
+      - [Repository forking](tooling/github-configuration.md/#repository-forking)
+  - [GitHub Enterprise Server Setting](tooling/github-configuration.md/#github-enterprise-server-setting)
+    - [GitHub Connect - Server statistics](tooling/github-configuration.md/#github-connect---server-statistics)
+  - [Resources](tooling/github-configuration.md/#resources)
+
+### GitLab


### PR DESCRIPTION
I've kickstarted the process of adding InnerSource tooling documentation, which is presently under progress and in a draft state.

## References to Original Issue and the Documentation Draft
- The originating issue can be found [here](https://github.com/InnerSourceCommons/ispo-working-group/issues/9)
- Our draft, in its current state, is available on [Google Docs](https://docs.google.com/document/d/1lPR90dIiWKlsNlV46xhGkR9pP0GNYmeAB7xOk-_MAYo/edit)

## Key Considerations
As we near completion of the draft for the SCM Strategy documentation under the ISPO working group, we've been contemplating the ideal location for the InnerSource tooling documentation. Presently, we've determined that the 'Managing InnerSource Project' book appears to be an apt place for the following reasons:

- The book does include an Infrastructure section, but we believe that it would significantly benefit from additional, concrete details on strategy and policy settings for the developer platform.
- The inclusion of this documentation could contribute to the ongoing evolution and improvement of the book. 
- Housing the documentation on GitHub aligns with our intention to encourage new contributors to join the project.
- Segmenting the documentation into several components is a viable approach as it will simplify the process of management and make it easier to identify maintainers