### PR TITLE
Update link to GitHub GQM graph page

### DIFF
--- a/measuring/use_gqm.md
+++ b/measuring/use_gqm.md
@@ -2,7 +2,7 @@
 
 *An overview of the Goals, Questions, and Metrics (GQM) catalog.*
 
-This page works better in GitHub; [click here](https://github.com/InnerSourceCommons/managing-inner-source-projects/blob/master/measuring/use_gqm.md).
+This page works better in GitHub; [click here](https://bit.ly/3tOrsbO).
 
 ```mermaid
 graph LR;


### PR DESCRIPTION
* The graph links only work in GitHub.
* Because of that we want to have a link in the book back to GitHub.
* For some reason the link in the book points to the page in the book.
* Maybe GitBook is auto-replacing GitHub links to point to the corresponding GitBook page instead.
* Hopefully this Bitly link won't get so-replaced.