### PR TITLE
GQM: Adoption trend and related metric

### DIFF
--- a/measuring/metrics/number-of-innersource-repositories.md
+++ b/measuring/metrics/number-of-innersource-repositories.md
@@ -14,7 +14,11 @@ Another challenge is that companies that use (entirely or partially) the concept
 
 **Unit of Measurement**: Number of repositories 
 
-**Interpretation**: Comparing an absolute number to a range does not make sense here. Comparing percentages (e.g. 10% of repositories are InnerSource) would make sense, but there is no strong base for comparison at the moment. What is more interesting for this metric is to observe its trend (how it changes over time).  
+**Interpretation**: Comparing an absolute number to a range does not make sense in this context. Comparing percentages does make sense, but there's no strong base for comparison.
+
+e.g. 10% of repositories are InnerSource
+
+It's more interesting to observe this metric's trend over time.  
 
 **Measuring**
 

--- a/measuring/metrics/number-of-innersource-repositories.md
+++ b/measuring/metrics/number-of-innersource-repositories.md
@@ -6,7 +6,7 @@ As projects adopt InnerSource, there are signs of such adoption on the correspon
 Examples are the presences of a `CONTRIBUTING.md` file, a "How to Contribute" section on the `README.md` file or repository topics in GitHub such as `innersource`.
 
 One challenge with this metric, is defining an InnerSource repository, as there is no clear cut definition.
-Some companies may have strict requirements for what an InnerSource repository is, others may adopt a _self-declaration_.
+Some companies may have strict requirements that define an InnerSource repository, while others may adopt a _self-declaration_.
 
 Another challenge is that companies that use (entirely or partially) the concept of a monorepo may need to find a different unit of measure to observe, as a single repository may be used for many projects or software packages.
 

--- a/measuring/metrics/number-of-innersource-repositories.md
+++ b/measuring/metrics/number-of-innersource-repositories.md
@@ -1,0 +1,28 @@
+[⬑ back to the overall graph](../use_gqm.md)
+
+# **Metric:** Number of InnerSource repositories
+
+As projects adopt InnerSource, there are signs of such adoption on the corresponding source code repositories.
+Examples are the presences of a `CONTRIBUTING.md` file, a "How to Contribute" section on the `README.md` file or repository topics in GitHub such as `innersource`.
+
+One challenge with this metric, is defining what an InnerSource repository is, as there is no clear cut for this definition.
+Some companies may have strict requirements for what an InnerSource repository is, others may adopt a _self-declaration_.
+
+Another challenge is that companies that use (entirely or partially) the concept of a monorepo may need to find a different unit of measure to observe, as a single repository may be used for many projects or software packages.
+
+**Synopsis**: Number of source code repositories that adopt InnerSource 
+
+**Unit of Measurement**: Number of repositories 
+
+**Interpretation**: Comparing an absolute number to a range does not make sense here. Comparing percentages (e.g. 10% of repositories are InnerSource) would make sense, but there is no strong base for comparison at the moment. What is more interesting for this metric is to observe its trend (how it changes over time).  
+
+**Measuring**
+
+Examples:
+- Measure the number of GitHub repositories that have the topic `innersource` assigned to them.
+- Measure the number of repositories that are above a given threshold on automated maturity score calculation
+
+## Related InnerSource Patterns
+- [InnerSource Portal](https://patterns.innersourcecommons.org/p/innersource-portal) - typically shows the number of InnerSource projects
+- [Standard Base Documentation](https://patterns.innersourcecommons.org/p/base-documentation) - describe common files used to document different aspects of InnerSource projects
+- [Maturity Model](https://patterns.innersourcecommons.org/p/maturity-model) - defines maturity model for different aspects of InnerSource projects, that could be used to decide on how classify a repository as InnerSource

--- a/measuring/metrics/number-of-innersource-repositories.md
+++ b/measuring/metrics/number-of-innersource-repositories.md
@@ -5,7 +5,7 @@
 As projects adopt InnerSource, there are signs of such adoption on the corresponding source code repositories.
 Examples are the presences of a `CONTRIBUTING.md` file, a "How to Contribute" section on the `README.md` file or repository topics in GitHub such as `innersource`.
 
-One challenge with this metric, is defining what an InnerSource repository is, as there is no clear cut for this definition.
+One challenge with this metric, is defining an InnerSource repository, as there is no clear cut definition.
 Some companies may have strict requirements for what an InnerSource repository is, others may adopt a _self-declaration_.
 
 Another challenge is that companies that use (entirely or partially) the concept of a monorepo may need to find a different unit of measure to observe, as a single repository may be used for many projects or software packages.

--- a/measuring/metrics/number-of-innersource-repositories.md
+++ b/measuring/metrics/number-of-innersource-repositories.md
@@ -23,7 +23,7 @@ It's more interesting to observe this metric's trend over time.
 **Measuring**
 
 Examples:
-- Measure the number of GitHub repositories that have the topic `innersource` assigned to them.
+- Measure the number of GitHub repositories tagged with the `innersource` topic.
 - Measure the number of repositories that are above a given threshold on automated maturity score calculation
 
 ## Related InnerSource Patterns

--- a/measuring/metrics/number-of-innersource-repositories.md
+++ b/measuring/metrics/number-of-innersource-repositories.md
@@ -24,5 +24,6 @@ Examples:
 
 ## Related InnerSource Patterns
 - [InnerSource Portal](https://patterns.innersourcecommons.org/p/innersource-portal) - typically shows the number of InnerSource projects
+- [Repository Activity Score](https://patterns.innersourcecommons.org/p/repository-activity-score) - defines a score for ranking projects based on activity, that could also be used as one of the criteria to consider a repository as InnerSource
 - [Standard Base Documentation](https://patterns.innersourcecommons.org/p/base-documentation) - describe common files used to document different aspects of InnerSource projects
 - [Maturity Model](https://patterns.innersourcecommons.org/p/maturity-model) - defines maturity model for different aspects of InnerSource projects, that could be used to decide on how classify a repository as InnerSource

--- a/measuring/metrics/number-of-innersource-repositories.md
+++ b/measuring/metrics/number-of-innersource-repositories.md
@@ -24,7 +24,7 @@ It's more interesting to observe this metric's trend over time.
 
 Examples:
 - Measure the number of GitHub repositories tagged with the `innersource` topic.
-- Measure the number of repositories that are above a given threshold on automated maturity score calculation
+- Measure the number of repositories that are above a given threshold using an automated maturity score calculation
 
 ## Related InnerSource Patterns
 - [InnerSource Portal](https://patterns.innersourcecommons.org/p/innersource-portal) - typically shows the number of InnerSource projects

--- a/measuring/metrics/number-of-innersource-repositories.md
+++ b/measuring/metrics/number-of-innersource-repositories.md
@@ -24,6 +24,6 @@ Examples:
 
 ## Related InnerSource Patterns
 - [InnerSource Portal](https://patterns.innersourcecommons.org/p/innersource-portal) - typically shows the number of InnerSource projects
-- [Repository Activity Score](https://patterns.innersourcecommons.org/p/repository-activity-score) - defines a score for ranking projects based on activity, that could also be used as one of the criteria to consider a repository as InnerSource
+- [Repository Activity Score](https://patterns.innersourcecommons.org/p/repository-activity-score) - defines a score for ranking active projects, usable as a criteria to identify InnerSource repositories
 - [Standard Base Documentation](https://patterns.innersourcecommons.org/p/base-documentation) - describe common files used to document different aspects of InnerSource projects
 - [Maturity Model](https://patterns.innersourcecommons.org/p/maturity-model) - defines maturity model for different aspects of InnerSource projects, that could be used to decide on how classify a repository as InnerSource

--- a/measuring/metrics/number-of-innersource-repositories.md
+++ b/measuring/metrics/number-of-innersource-repositories.md
@@ -26,4 +26,4 @@ Examples:
 - [InnerSource Portal](https://patterns.innersourcecommons.org/p/innersource-portal) - typically shows the number of InnerSource projects
 - [Repository Activity Score](https://patterns.innersourcecommons.org/p/repository-activity-score) - defines a score for ranking active projects, usable as a criteria to identify InnerSource repositories
 - [Standard Base Documentation](https://patterns.innersourcecommons.org/p/base-documentation) - describe common files used to document different aspects of InnerSource projects
-- [Maturity Model](https://patterns.innersourcecommons.org/p/maturity-model) - defines maturity model for different aspects of InnerSource projects, that could be used to decide on how classify a repository as InnerSource
+- [Maturity Model](https://patterns.innersourcecommons.org/p/maturity-model) - defines levels of maturity for InnerSource projects and can help classify a repository as InnerSource.

--- a/measuring/questions/adoption-trend.md
+++ b/measuring/questions/adoption-trend.md
@@ -9,4 +9,4 @@ Lack of adoption, or stagnant adoption may reveal that it is necessary to rethin
 
 | **Metric** | **How it answers the question** | **Gotchas** |
 | --- | --- | --- |
-| [Number of InnerSource repositories](../metrics/number-of-innersource-repositories.md) | The number of (source code) repositories that are consider InnerSource are directly related to the adoption of the practice. | Depending on how you define _InnerSource repositories_, it can be prone to false positives and/or negatives |
+| [Number of InnerSource repositories](../metrics/number-of-innersource-repositories.md) | The number of (source code) repositories that are directly related to the adoption of the practice. | Depending on how you define _InnerSource repositories_, it can report incorrect results |

--- a/measuring/questions/adoption-trend.md
+++ b/measuring/questions/adoption-trend.md
@@ -1,0 +1,12 @@
+[⬑ back to the overall graph](../use_gqm.md)
+
+# **Question:** What is the InnerSource adoption trend?
+
+This question is something an InnerSource program asks while fostering the adoption of InnerSource.
+Lack of adoption, or stagnant adoption may reveal that it is necessary to rethink the program strategy or investigate impediments.
+
+## Related Metrics
+
+| **Metric** | **How it answers the question** | **Gotchas** |
+| --- | --- | --- |
+| [Number of InnerSource repositories](../metrics/number-of-innersource-repositories.md) | The number of (source code) repositories that are consider InnerSource are directly related to the adoption of the practice. | Depending on how you define _InnerSource repositories_, it can be pronte to false positives and/or negatives |

--- a/measuring/use_gqm.md
+++ b/measuring/use_gqm.md
@@ -34,9 +34,12 @@ graph LR;
     %% begin nodes
     find-projects.md[Find InnerSource Projects]
     reduce-duplication.md[Reduce duplication]
+    adoption-trend.md[What is the InnerSource adoption trend?]
     who-contributes.md[Who contributes to the InnerSource project?]
     who-uses.md[Who uses the InnerSource project?]
     code-contributions.md[Code contributions]
+    contribution-distance.md[Contribution Distance]
+    number-of-innersource-repositories.md[Number of InnerSource repositories]
     usage-count.md[Usage count]
     %% end nodes
 
@@ -44,16 +47,21 @@ graph LR;
     find-projects.md-->who-uses.md
     find-projects.md-->who-contributes.md
     reduce-duplication.md-->who-uses.md
+    adoption-trend.md-->number-of-innersource-repositories.md
     who-contributes.md-->code-contributions.md
+    who-contributes.md-->contribution-distance.md
     who-uses.md-->usage-count.md
     %% end edges
 
     %% begin clicks
-    click find-projects.md "https://github.com/InnerSourceCommons/managing-inner-source-projects/blob/main/measuring/goals/find-projects.md" "Find InnerSource Projects" _blank
+    click find-projects.md "https://github.com/InnerSourceCommons/managing-inner-source-projects/blob/main/measuring/goals/find-projects.md" "Find InnerSource Projects"
     click reduce-duplication.md "https://github.com/InnerSourceCommons/managing-inner-source-projects/blob/main/measuring/goals/reduce-duplication.md" "Reduce duplication"
+    click adoption-trend.md "https://github.com/InnerSourceCommons/managing-inner-source-projects/blob/main/measuring/questions/adoption-trend.md" "What is the InnerSource adoption trend?"
     click who-contributes.md "https://github.com/InnerSourceCommons/managing-inner-source-projects/blob/main/measuring/questions/who-contributes.md" "Who contributes to the InnerSource project?"
     click who-uses.md "https://github.com/InnerSourceCommons/managing-inner-source-projects/blob/main/measuring/questions/who-uses.md" "Who uses the InnerSource project?"
     click code-contributions.md "https://github.com/InnerSourceCommons/managing-inner-source-projects/blob/main/measuring/metrics/code-contributions.md" "Code contributions"
+    click contribution-distance.md "https://github.com/InnerSourceCommons/managing-inner-source-projects/blob/main/measuring/metrics/contribution-distance.md" "Contribution Distance"
+    click number-of-innersource-repositories.md "https://github.com/InnerSourceCommons/managing-inner-source-projects/blob/main/measuring/metrics/number-of-innersource-repositories.md" "Number of InnerSource repositories"
     click usage-count.md "https://github.com/InnerSourceCommons/managing-inner-source-projects/blob/main/measuring/metrics/usage-count.md" "Usage count"
     %% end clicks
 
@@ -69,10 +77,10 @@ graph LR;
         class goal,find-projects.md,reduce-duplication.md goals
 
         classDef questions stroke:orange,stroke-width:2px;
-        class question,who-contributes.md,who-uses.md questions
+        class question,adoption-trend.md,who-contributes.md,who-uses.md questions
 
         classDef metrics stroke:purple,stroke-width:2px;
-        class metric,code-contributions.md,usage-count.md metrics
+        class metric,code-contributions.md,contribution-distance.md,number-of-innersource-repositories.md,usage-count.md metrics
       end  
   
 ```


### PR DESCRIPTION
This commit is based on the a value that is observed at SAP, where we periodically check the number of projects that have self-registered to our InnerSource Projects portal, by assigning a topic to their repositories.

I tried to generalize it a bit, so it goes a little bit beyond on how we use it.

Related issues:
- https://github.com/InnerSourceCommons/ispo-working-group/issues/109